### PR TITLE
Ignore url.Query

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -60,20 +60,22 @@ func (s *SQLFormatter) Format() error {
 			if fun, ok := x.Fun.(*ast.SelectorExpr); ok {
 				funcName := fun.Sel.Name
 				if funcName == QUERY || funcName == QUERYROW || funcName == EXEC {
-					if arg, ok := x.Args[0].(*ast.BasicLit); ok {
-						sqlStmt := arg.Value
-						if !strings.HasPrefix(sqlStmt, "`") {
-							return true
-						}
-						src := strings.Trim(sqlStmt, "`")
-						formattedStmt, e := s.Formatter.Format(src)
-						if e != nil {
-							err = &FormatError{
-								Msg: e.Error(),
+					if len(x.Args) > 0 {
+						if arg, ok := x.Args[0].(*ast.BasicLit); ok {
+							sqlStmt := arg.Value
+							if !strings.HasPrefix(sqlStmt, "`") {
+								return true
 							}
-							return false
+							src := strings.Trim(sqlStmt, "`")
+							formattedStmt, e := s.Formatter.Format(src)
+							if e != nil {
+								err = &FormatError{
+									Msg: e.Error(),
+								}
+								return false
+							}
+							arg.Value = "`" + formattedStmt + "`"
 						}
-						arg.Value = "`" + formattedStmt + "`"
 					}
 				}
 			}

--- a/ast_test.go
+++ b/ast_test.go
@@ -3,6 +3,7 @@ package sqlfmt
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,17 +29,23 @@ func TestNewSQLFormatter(t *testing.T) {
 	})
 }
 
-func TestFormatInAst(t *testing.T) {
-	f, err := os.Open("./testdata/testing_gofile.go")
-	if err != nil {
-		t.Fatalf("ERROR: %#v", err)
-	}
+var testFiles, _ = filepath.Glob("./testdata/*.go")
 
-	sfmt, err := NewSQLFormatter(f)
-	if err != nil {
-		t.Fatalf("ERROR %#v", err)
-	}
-	if err := sfmt.Format(); err != nil {
-		t.Errorf("ERROR:%#v", err)
+func TestFormatInAst(t *testing.T) {
+	for _, file := range testFiles {
+		t.Run(file, func(t *testing.T) {
+			f, err := os.Open(file)
+			if err != nil {
+				t.Fatalf("ERROR: %#v", err)
+			}
+
+			sfmt, err := NewSQLFormatter(f)
+			if err != nil {
+				t.Fatalf("ERROR %#v", err)
+			}
+			if err := sfmt.Format(); err != nil {
+				t.Errorf("ERROR:%#v", err)
+			}
+		})
 	}
 }

--- a/testdata/testing_gofile_url_query.go
+++ b/testdata/testing_gofile_url_query.go
@@ -1,0 +1,10 @@
+package sqlformatter
+
+import (
+	"net/url"
+)
+
+func parseQuery() int {
+	u := url.Parse("https://example.org/?a=1&a=2&b=&=3&&&&")
+	u.Query()
+}


### PR DESCRIPTION
The current implementation panics if it finds `url.Query()`.