### PR TITLE
Add Go version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kanmu/go-sqlfmt
 
+go 1.13
+
 require github.com/pkg/errors v0.8.1


### PR DESCRIPTION
The Go version is forcibly added to `go.mod` from Go 1.13.
Therefore, I want to commit the Go version because the difference comes out.