### PR TITLE
Fix gosimple

### DIFF
--- a/sqlfmt/parser/group/reindenter.go
+++ b/sqlfmt/parser/group/reindenter.go
@@ -30,11 +30,11 @@ func write(buf *bytes.Buffer, token lexer.Token, indent int) {
 	case token.IsNeedNewLineBefore():
 		buf.WriteString(fmt.Sprintf("%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), token.Value))
 	case token.Type == lexer.COMMA:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case token.Type == lexer.DO:
 		buf.WriteString(fmt.Sprintf("%s%s%s", NewLine, token.Value, WhiteSpace))
 	case strings.HasPrefix(token.Value, "::"):
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case token.Type == lexer.WITH:
 		buf.WriteString(fmt.Sprintf("%s%s", NewLine, token.Value))
 	default:
@@ -59,7 +59,7 @@ func writeWithComma(buf *bytes.Buffer, v interface{}, indent int) error {
 		if columnCount == 0 {
 			buf.WriteString(fmt.Sprintf("%s%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), DoubleWhiteSpace, str))
 		} else if strings.HasPrefix(token.Value, "::") {
-			buf.WriteString(fmt.Sprintf("%s", str))
+			buf.WriteString(str)
 		} else {
 			buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, str))
 		}
@@ -105,10 +105,10 @@ func writeCase(buf *bytes.Buffer, token lexer.Token, indent int, hasCommaBefore 
 		case lexer.END:
 			buf.WriteString(fmt.Sprintf("%s%s%s%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), DoubleWhiteSpace, WhiteSpace, WhiteSpace, token.Value))
 		case lexer.COMMA:
-			buf.WriteString(fmt.Sprintf("%s", token.Value))
+			buf.WriteString(token.Value)
 		default:
 			if strings.HasPrefix(token.Value, "::") {
-				buf.WriteString(fmt.Sprintf("%s", token.Value))
+				buf.WriteString(token.Value)
 			} else {
 				buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 			}
@@ -120,10 +120,10 @@ func writeCase(buf *bytes.Buffer, token lexer.Token, indent int, hasCommaBefore 
 		case lexer.WHEN, lexer.ELSE:
 			buf.WriteString(fmt.Sprintf("%s%s%s%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), DoubleWhiteSpace, WhiteSpace, DoubleWhiteSpace, token.Value))
 		case lexer.COMMA:
-			buf.WriteString(fmt.Sprintf("%s", token.Value))
+			buf.WriteString(token.Value)
 		default:
 			if strings.HasPrefix(token.Value, "::") {
-				buf.WriteString(fmt.Sprintf("%s", token.Value))
+				buf.WriteString(token.Value)
 			} else {
 				buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 			}
@@ -138,7 +138,7 @@ func writeJoin(buf *bytes.Buffer, token lexer.Token, indent int, isFirst bool) {
 	case token.Type == lexer.ON || token.Type == lexer.USING:
 		buf.WriteString(fmt.Sprintf("%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), token.Value))
 	case strings.HasPrefix(token.Value, "::"):
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	default:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	}
@@ -147,15 +147,15 @@ func writeJoin(buf *bytes.Buffer, token lexer.Token, indent int, isFirst bool) {
 func writeFunction(buf *bytes.Buffer, token, prev lexer.Token, indent, columnCount int, inColumnArea bool) {
 	switch {
 	case prev.Type == lexer.STARTPARENTHESIS || token.Type == lexer.STARTPARENTHESIS || token.Type == lexer.ENDPARENTHESIS:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case token.Type == lexer.FUNCTION && columnCount == 0 && inColumnArea:
 		buf.WriteString(fmt.Sprintf("%s%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent), DoubleWhiteSpace, token.Value))
 	case token.Type == lexer.FUNCTION:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	case token.Type == lexer.COMMA:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case strings.HasPrefix(token.Value, "::"):
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	default:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	}
@@ -168,13 +168,13 @@ func writeParenthesis(buf *bytes.Buffer, token lexer.Token, indent, columnCount 
 	case token.Type == lexer.STARTPARENTHESIS:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	case token.Type == lexer.ENDPARENTHESIS:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case token.Type == lexer.COMMA:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case hasStartBefore:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	case strings.HasPrefix(token.Value, "::"):
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	default:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	}
@@ -191,7 +191,7 @@ func writeSubquery(buf *bytes.Buffer, token lexer.Token, indent, columnCount int
 	case token.Type == lexer.ENDPARENTHESIS:
 		buf.WriteString(fmt.Sprintf("%s%s%s", NewLine, strings.Repeat(DoubleWhiteSpace, indent-1), token.Value))
 	case strings.HasPrefix(token.Value, "::"):
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	default:
 		buf.WriteString(fmt.Sprintf("%s%s", WhiteSpace, token.Value))
 	}
@@ -204,7 +204,7 @@ func writeTypeCast(buf *bytes.Buffer, token lexer.Token) {
 	case lexer.COMMA:
 		buf.WriteString(fmt.Sprintf("%s%s", token.Value, WhiteSpace))
 	default:
-		buf.WriteString(fmt.Sprintf("%s", token.Value))
+		buf.WriteString(token.Value)
 	}
 }
 


### PR DESCRIPTION
Fixed the following warnings:
`S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)`