### PR TITLE
Fix index out of bounds panic

### DIFF
--- a/sqlfmt/parser/retriever.go
+++ b/sqlfmt/parser/retriever.go
@@ -91,7 +91,7 @@ func (r *Retriever) appendGroupsToResult() error {
 		token lexer.Token
 	)
 	for {
-		if idx > len(r.TokenSource) {
+		if idx >= len(r.TokenSource) {
 			return fmt.Errorf("the retriever may have not found the endToken")
 		}
 


### PR DESCRIPTION
I ran into a panic with the following stacktrace:

```
panic(0x113abc0, 0xc0002c7f60)
	/usr/local/Cellar/go/1.15.7_1/libexec/src/runtime/panic.go:969 +0x1b9
github.com/kanmu/go-sqlfmt/sqlfmt/parser.(*Retriever).appendGroupsToResult(0xc0002cec60, 0xc0002cec60, 0xc00012fa38)
	/Users/jmickelson/go/src/stash.teslamotors.com/cas/ion/lineside/vendor/github.com/kanmu/go-sqlfmt/sqlfmt/parser/retriever.go:98 +0x46e
github.com/kanmu/go-sqlfmt/sqlfmt/parser.(*Retriever).Retrieve(0xc0002cec60, 0x3b, 0x40, 0xc0002cec60, 0x21, 0xc0002ec000, 0x20)
	/Users/jmickelson/go/src/stash.teslamotors.com/cas/ion/lineside/vendor/github.com/kanmu/go-sqlfmt/sqlfmt/parser/retriever.go:79 +0x2f
github.com/kanmu/go-sqlfmt/sqlfmt/parser.ParseTokens(0xc0002ec000, 0x3b, 0x40, 0x40, 0x0, 0x0, 0x25, 0xc000019a70)
	/Users/jmickelson/go/src/stash.teslamotors.com/cas/ion/lineside/vendor/github.com/kanmu/go-sqlfmt/sqlfmt/parser/parser.go:36 +0x10b
github.com/kanmu/go-sqlfmt/sqlfmt.Format(0xc0002e4400, 0x3e8, 0xc00012fc30, 0x5, 0xc0002db2c8, 0xc0002c32e7, 0x3)
	/Users/jmickelson/go/src/stash.teslamotors.com/cas/ion/lineside/vendor/github.com/kanmu/go-sqlfmt/sqlfmt/format.go:26 +0x20b
```

It appears that there is an off by one error in an index range check.  This PR fixes it.

Let me know if you have any questions or there's anything you'd like me to tweak.