### PR TITLE
Show help when no input is given

### DIFF
--- a/sqlfmt.go
+++ b/sqlfmt.go
@@ -40,6 +40,10 @@ func isGoFile(info os.FileInfo) bool {
 	return !info.IsDir() && !strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".go")
 }
 
+func isPipeInput(info os.FileInfo) bool {
+	return info.Mode()&os.ModeCharDevice == 0
+}
+
 func visitFile(path string, info os.FileInfo, err error) error {
 	if err == nil && isGoFile(info) {
 		err = processFile(path, nil, os.Stdout)
@@ -107,6 +111,10 @@ func sqlfmtMain() {
 
 	// the user is piping their source into go-sqlfmt
 	if flag.NArg() == 0 {
+		if info, _ := os.Stdin.Stat(); !isPipeInput(info) {
+			flag.Usage()
+			return
+		}
 		if *write {
 			log.Fatal("can not use -w while using pipeline")
 		}


### PR DESCRIPTION
when no input is given, show help as follows,

```
$ sqlfmt
usage: sqlfmt [flags] [path ...]
  -d    display diffs instead of rewriting files
  -distance int
        write the distance from the edge to the begin of SQL statements
  -l    list files whose formatting differs from goreturns's
  -w    write result to (source) file instead of stdout

```

it also works fine when pipe input is given 

```
$ cat sqlfmt/testdata/testing_gofile.go | sqlfmt
package sqlfmt

import (
        "database/sql"
)

func sendSQL() int {
        var id int
        var db *sql.DB
        db.QueryRow(`
SELECT
  any (
    SELECT
      xxx
    FROM xxx
  )
FROM xxx
WHERE xxx
LIMIT xxx`).Scan(&id)
        return id
}

```

