### PR TITLE
Fix a crash when parsing nested function calls (see added test case).

### DIFF
--- a/sqlfmt/format_test.go
+++ b/sqlfmt/format_test.go
@@ -865,4 +865,12 @@ FROM xxx`,
 LOCK table
 IN xxx`,
 	},
+	{
+		src: `select true from m where t < date_trunc('DAY', to_timestamp('2022-01-01'))`,
+		want: `
+SELECT
+  true
+FROM m
+WHERE t < DATE_TRUNC('DAY', TO_TIMESTAMP('2022-01-01'))`,
+	},
 }

--- a/sqlfmt/lexer/token.go
+++ b/sqlfmt/lexer/token.go
@@ -81,6 +81,7 @@ const (
 	OVERLAPS
 	NATURAL
 	CROSS
+	TIME
 	ZONE
 	NULLS
 	LAST
@@ -93,6 +94,7 @@ const (
 )
 
 // TokenType is an alias type that represents a kind of token
+//go:generate stringer -type=TokenType
 type TokenType int
 
 // Token is a token struct

--- a/sqlfmt/lexer/tokenizer.go
+++ b/sqlfmt/lexer/tokenizer.go
@@ -315,16 +315,24 @@ func (t *Tokenizer) append(v string) {
 }
 
 func (t *Tokenizer) isSQLKeyWord(v string) (TokenType, bool) {
+	if r, _, err := t.r.ReadRune(); err == nil && string(r) == StartParenthesis {
+		t.unread()
+
+		if ttype, ok := typeWithParenMap[v]; ok {
+			return ttype, true
+		} else {
+			// Assume everything else are functions (either from standards, or vendor specific)
+			return FUNCTION, true
+		}
+	} else {
+		t.unread()
+	}
+
+	// Keywords will be formatted in capital cases
 	if ttype, ok := sqlKeywordMap[v]; ok {
 		return ttype, ok
-	} else if ttype, ok := typeWithParenMap[v]; ok {
-		if r, _, err := t.r.ReadRune(); err == nil && string(r) == StartParenthesis {
-			t.unread()
-			return ttype, ok
-		}
-		t.unread()
-		return IDENT, ok
 	}
+
 	return IDENT, false
 }
 
@@ -376,6 +384,7 @@ var sqlKeywordMap = map[string]TokenType{
 	"FILTER":      FILTER,
 	"WITHIN":      WITHIN,
 	"COLLATE":     COLLATE,
+	"INTERVAL":    INTERVAL,
 	"INTERSECT":   INTERSECT,
 	"EXCEPT":      EXCEPT,
 	"OFFSET":      OFFSET,
@@ -386,6 +395,7 @@ var sqlKeywordMap = map[string]TokenType{
 	"OVERLAPS":    OVERLAPS,
 	"NATURAL":     NATURAL,
 	"CROSS":       CROSS,
+	"TIME":        TIME,
 	"ZONE":        ZONE,
 	"NULLS":       NULLS,
 	"LAST":        LAST,
@@ -395,46 +405,22 @@ var sqlKeywordMap = map[string]TokenType{
 }
 
 var typeWithParenMap = map[string]TokenType{
-	"SUM":             FUNCTION,
-	"AVG":             FUNCTION,
-	"MAX":             FUNCTION,
-	"MIN":             FUNCTION,
-	"COUNT":           FUNCTION,
-	"COALESCE":        FUNCTION,
-	"EXTRACT":         FUNCTION,
-	"OVERLAY":         FUNCTION,
-	"POSITION":        FUNCTION,
-	"CAST":            FUNCTION,
-	"SUBSTRING":       FUNCTION,
-	"TRIM":            FUNCTION,
-	"XMLELEMENT":      FUNCTION,
-	"XMLFOREST":       FUNCTION,
-	"XMLCONCAT":       FUNCTION,
-	"RANDOM":          FUNCTION,
-	"DATE_PART":       FUNCTION,
-	"DATE_TRUNC":      FUNCTION,
-	"ARRAY_AGG":       FUNCTION,
-	"PERCENTILE_DISC": FUNCTION,
-	"GREATEST":        FUNCTION,
-	"LEAST":           FUNCTION,
-	"OVER":            FUNCTION,
-	"ROW_NUMBER":      FUNCTION,
-	"BIG":             TYPE,
-	"BIGSERIAL":       TYPE,
-	"BOOLEAN":         TYPE,
-	"CHAR":            TYPE,
-	"BIT":             TYPE,
-	"TEXT":            TYPE,
-	"INTEGER":         TYPE,
-	"NUMERIC":         TYPE,
-	"DECIMAL":         TYPE,
-	"DEC":             TYPE,
-	"FLOAT":           TYPE,
-	"CUSTOMTYPE":      TYPE,
-	"VARCHAR":         TYPE,
-	"VARBIT":          TYPE,
-	"TIMESTAMP":       TYPE,
-	"TIME":            TYPE,
-	"SECOND":          TYPE,
-	"INTERVAL":        TYPE,
+	"BIG":        TYPE,
+	"BIGSERIAL":  TYPE,
+	"BOOLEAN":    TYPE,
+	"CHAR":       TYPE,
+	"BIT":        TYPE,
+	"TEXT":       TYPE,
+	"INTEGER":    TYPE,
+	"NUMERIC":    TYPE,
+	"DECIMAL":    TYPE,
+	"DEC":        TYPE,
+	"FLOAT":      TYPE,
+	"CUSTOMTYPE": TYPE,
+	"VARCHAR":    TYPE,
+	"VARBIT":     TYPE,
+	"TIMESTAMP":  TYPE,
+	"TIME":       TYPE,
+	"SECOND":     TYPE,
+	"INTERVAL":   TYPE,
 }

--- a/sqlfmt/lexer/tokenizer_test.go
+++ b/sqlfmt/lexer/tokenizer_test.go
@@ -14,7 +14,7 @@ func TestGetTokens(t *testing.T) {
 		{Type: COMMA, Value: ","},
 		{Type: IDENT, Value: "age"},
 		{Type: COMMA, Value: ","},
-		{Type: IDENT, Value: "SUM"},
+		{Type: IDENT, Value: "sum"},
 		{Type: COMMA, Value: ","},
 		{Type: FUNCTION, Value: "SUM"},
 		{Type: STARTPARENTHESIS, Value: "("},


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10f0e78]

goroutine 78 [running]:
testing.tRunner.func1.2({0x1106160, 0x1209f70})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1106160, 0x1209f70})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/kanmu/go-sqlfmt/sqlfmt/parser.(*Retriever).appendGroupsToResult(0x0)
	go-sqlfmt/sqlfmt/parser/retriever.go:94 +0x38
github.com/kanmu/go-sqlfmt/sqlfmt/parser.(*Retriever).Retrieve(0x0)
	go-sqlfmt/sqlfmt/parser/retriever.go:79 +0x1e
github.com/kanmu/go-sqlfmt/sqlfmt/parser.ParseTokens({0xc000239b00, 0x11, 0x20})
	go-sqlfmt/sqlfmt/parser/parser.go:36 +0x17d